### PR TITLE
Allow the methods on the generated struct to be unused.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,7 @@ macro_rules! bitflags {
             }
         }
 
+        #[allow(dead_code)]
         impl $BitFlags {
             /// Returns an empty set of flags.
             #[inline]


### PR DESCRIPTION
Fixed #22.