### PR TITLE
Keep clippy happy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@ macro_rules! bitflags {
                 // defined variants, leaving only the undefined ones with the
                 // bit value of 0.
                 #[allow(dead_code)]
+                #[allow(unused_assignments)]
                 mod dummy {
                     // Now we define the "undefined" versions of the flags.
                     // This way, all the names exist, even if some are #[cfg]ed
@@ -166,14 +167,14 @@ macro_rules! bitflags {
                         // Only ones that are #[cfg]ed out will be 0.
                         use super::*;
 
-                        let mut _first = true;
+                        let mut first = true;
                         $(
                             // $Flag.bits == 0 means that $Flag doesn't exist
                             if $Flag.bits != 0 && self_.contains($Flag) {
-                                if !_first {
+                                if !first {
                                     try!(f.write_str(" | "));
                                 }
-                                _first = false;
+                                first = false;
                                 try!(f.write_str(stringify!($Flag)));
                             }
                         )+


### PR DESCRIPTION
Macro expansion happens before clippy does its thing - probably there's no other way - so code that uses `bitflags` can't be clippy-clean unless `bitflags` is clippy-clean.

When the tweaked variable is called `_first`, clippy complains that it begins with an underscore even though it is actually used.

But on re-naming as `first` we find that the second assignment of the variable isn't always used (presumably in cases where there's only one flag present).  So need to `#[allow(unused_assignments)]` too.