### PR TITLE
Implement assignment operators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,10 +104,10 @@
 ///
 /// The following operator traits are implemented for the generated `struct`:
 ///
-/// - `BitOr`: union
-/// - `BitAnd`: intersection
-/// - `BitXor`: toggle
-/// - `Sub`: set difference
+/// - `BitOr` and `BitOrAssign`: union
+/// - `BitAnd` and `BitAndAssign`: intersection
+/// - `BitXor` and `BitXorAssign`: toggle
+/// - `Sub` and `SubAssign`: set difference
 /// - `Not`: set complement
 ///
 /// # Methods
@@ -286,6 +286,15 @@ macro_rules! bitflags {
             }
         }
 
+        impl ::std::ops::BitOrAssign for $BitFlags {
+
+            /// Adds the set of flags.
+            #[inline]
+            fn bitor_assign(&mut self, other: $BitFlags) {
+                self.bits |= other.bits;
+            }
+        }
+
         impl ::std::ops::BitXor for $BitFlags {
             type Output = $BitFlags;
 
@@ -293,6 +302,15 @@ macro_rules! bitflags {
             #[inline]
             fn bitxor(self, other: $BitFlags) -> $BitFlags {
                 $BitFlags { bits: self.bits ^ other.bits }
+            }
+        }
+
+        impl ::std::ops::BitXorAssign for $BitFlags {
+
+            /// Toggles the set of flags.
+            #[inline]
+            fn bitxor_assign(&mut self, other: $BitFlags) {
+                self.bits ^= other.bits;
             }
         }
 
@@ -306,6 +324,16 @@ macro_rules! bitflags {
             }
         }
 
+        impl ::std::ops::BitAndAssign for $BitFlags {
+
+
+            /// Disables all flags disabled in the set.
+            #[inline]
+            fn bitand_assign(&mut self, other: $BitFlags) {
+                self.bits &= other.bits;
+            }
+        }
+
         impl ::std::ops::Sub for $BitFlags {
             type Output = $BitFlags;
 
@@ -313,6 +341,15 @@ macro_rules! bitflags {
             #[inline]
             fn sub(self, other: $BitFlags) -> $BitFlags {
                 $BitFlags { bits: self.bits & !other.bits }
+            }
+        }
+
+        impl ::std::ops::SubAssign for $BitFlags {
+
+            /// Disables all flags enabled in the set.
+            #[inline]
+            fn sub_assign(&mut self, other: $BitFlags) {
+                self.bits &= !other.bits;
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(op_assign_traits)]
+#![feature(augmented_assignments)]
 // Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -19,6 +21,7 @@
 /// # Example
 ///
 /// ```{.rust}
+/// #![feature(op_assign_traits)]
 /// #[macro_use]
 /// extern crate bitflags;
 ///
@@ -47,6 +50,7 @@
 /// implementations:
 ///
 /// ```{.rust}
+/// #![feature(op_assign_traits)]
 /// #[macro_use]
 /// extern crate bitflags;
 ///
@@ -558,6 +562,24 @@ mod tests {
         let mut m4 = AnotherSetOfFlags::empty();
         m4.toggle(AnotherSetOfFlags::empty());
         assert!(m4 == AnotherSetOfFlags::empty());
+    }
+
+    #[test]
+    fn test_assignment_operators() {
+        let mut m1 = Flags::empty();
+        let e1 = FlagA | FlagC;
+        // union
+        m1 |= FlagA;
+        assert!(m1 == FlagA);
+        // intersection
+        m1 &= e1;
+        assert!(m1 == FlagA);
+        // set difference
+        m1 -= m1;
+        assert!(m1 == Flags::empty());
+        // toggle
+        m1 ^= e1;
+        assert!(m1 == e1);
     }
 
     #[test]


### PR DESCRIPTION
The patch implements assignment operators for bitflag structs.

If assignment operators become stable (https://github.com/rust-lang/rust/issues/28235), it can be merged.

Currently, anyone using the `bitflags` macro would need to enable `op_assign_traits` for his crate
```
#![feature(op_assign_traits)]
```
and anyone using the assignment operators would need to enable `augmented_assignments` for his crate
```
#![feature(augmented_assignments)]
```