### PR TITLE
Apply suggestion of clippy if_not_else lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,10 +316,10 @@ macro_rules! bitflags {
             /// representation contains bits that do not correspond to a flag.
             #[inline]
             pub fn from_bits(bits: $T) -> $crate::__core::option::Option<$BitFlags> {
-                if (bits & !$BitFlags::all().bits()) != 0 {
-                    $crate::__core::option::Option::None
-                } else {
+                if (bits & !$BitFlags::all().bits()) == 0 {
                     $crate::__core::option::Option::Some($BitFlags { bits: bits })
+                } else {
+                    $crate::__core::option::Option::None
                 }
             }
 


### PR DESCRIPTION
I would not normally meddle with important dependencies just for style nitpicking, but since this is a macro, clippy will happily warn in downstream projects where the macro is invoked (https://github.com/Manishearth/rust-clippy/issues/407).

This change is simple enough, and I don't think it makes things less readable.