### PR TITLE
Remove the assignment_operators feature, its requirements are now stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ script:
   - cargo test --verbose
   - cargo test --verbose --features no_std
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-       cargo test --verbose --features assignment_operators;
-       cargo test --verbose --features "no_std assignment_operators";
+       cargo test --verbose --features "no_std";
     fi
   - cargo doc
 after_success: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ A macro to generate structures which behave like bitflags.
 
 [features]
 no_std = []
-assignment_operators = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,6 @@
 // must be disabled by default to allow the crate to work on older rust versions.
 #![cfg_attr(all(feature = "no_std", not(test)), no_std)]
 
-#![cfg_attr(feature = "assignment_operators", feature(augmented_assignments))]
-#![cfg_attr(all(feature = "assignment_operators", test), feature(op_assign_traits))]
-
 #[cfg(all(feature = "no_std", not(test)))]
 #[macro_use]
 extern crate core as std;
@@ -37,7 +34,6 @@ pub use std as __core;
 /// # Example
 ///
 /// ```{.rust}
-/// #![cfg_attr(feature = "assignment_operators", feature(augmented_assignments, op_assign_traits))]
 /// #[macro_use]
 /// extern crate bitflags;
 ///
@@ -66,7 +62,6 @@ pub use std as __core;
 /// implementations:
 ///
 /// ```{.rust}
-/// #![cfg_attr(feature = "assignment_operators", feature(augmented_assignments, op_assign_traits))]
 /// #[macro_use]
 /// extern crate bitflags;
 ///
@@ -384,7 +379,6 @@ macro_rules! bitflags {
             }
         }
 
-        #[cfg(feature="assignment_operators")]
         impl $crate::__core::ops::BitOrAssign for $BitFlags {
 
             /// Adds the set of flags.
@@ -404,7 +398,6 @@ macro_rules! bitflags {
             }
         }
 
-        #[cfg(feature="assignment_operators")]
         impl $crate::__core::ops::BitXorAssign for $BitFlags {
 
             /// Toggles the set of flags.
@@ -424,7 +417,6 @@ macro_rules! bitflags {
             }
         }
 
-        #[cfg(feature="assignment_operators")]
         impl $crate::__core::ops::BitAndAssign for $BitFlags {
 
             /// Disables all flags disabled in the set.
@@ -444,7 +436,6 @@ macro_rules! bitflags {
             }
         }
 
-        #[cfg(feature="assignment_operators")]
         impl $crate::__core::ops::SubAssign for $BitFlags {
 
             /// Disables all flags enabled in the set.
@@ -671,7 +662,6 @@ mod tests {
         assert_eq!(m4, AnotherSetOfFlags::empty());
     }
 
-    #[cfg(feature="assignment_operators")]
     #[test]
     fn test_assignment_operators() {
         let mut m1 = Flags::empty();

--- a/tests/external.rs
+++ b/tests/external.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![cfg_attr(all(feature = "assignment_operators", test), feature(op_assign_traits))]
 
 #[macro_use]
 extern crate bitflags;

--- a/tests/external_no_std.rs
+++ b/tests/external_no_std.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "no_std")]
 #![allow(dead_code)]
 #![no_std]
-#![cfg_attr(all(feature = "assignment_operators", test), feature(op_assign_traits))]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
With rust 1.8, augmented_assignments and op_assign_traits are stable.  Thus
just enable them globally.