### PR TITLE
Recommend current bitflags crate version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-
-bitflags = "0.3"
+bitflags = "0.6"
 ```
 
 and this to your crate root:


### PR DESCRIPTION
Yes, that's the only change! Build errors (missing `pub`) occurred with the currently recommended `0.3` version.