### PR TITLE
Update documentation links and attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
 
 name = "bitflags"
-version = "0.8.0" # also update number in readme for breaking changes
+# NB: When modifying, also modify:
+#   1. html_root_url in lib.rs
+#   2. number in readme (for breaking changes)
+version = "0.8.0"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 keywords = ["bit", "bitmask", "bitflags"]
 readme = "README.md"
 repository = "https://github.com/rust-lang/bitflags"
 homepage = "https://github.com/rust-lang/bitflags"
-documentation = "https://doc.rust-lang.org/bitflags"
+documentation = "https://docs.rs/bitflags"
 categories = ["no-std"]
 description = """
 A macro to generate structures which behave like bitflags.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Rust macro to generate structures which behave like a set of bitflags
 
 [![Build Status](https://travis-ci.org/rust-lang-nursery/bitflags.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/bitflags)
 
-[Documentation](https://doc.rust-lang.org/bitflags)
+[Documentation](https://docs.rs/bitflags)
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 
 #![no_std]
 
+#![doc(html_root_url = "https://docs.rs/bitflags/0.8.2")]
 // When compiled for the rustc compiler itself we want to make sure that this is
 // an unstable crate.
 #![cfg_attr(rustbuild, feature(staged_api))]


### PR DESCRIPTION
Fulfills #78 

I also updated the `Documentation` link in the README as I'm fairly sure it should point to the same documentation as the Cargo.toml.

Now, in doing this, I noticed that the current version in the Cargo.toml of this repo (0.8.0) **does not match** the version of bitflags that is currently published as a crate (0.8.2). I made the `html_root_url` attribute link to version 0.8.2 on docs.rs.

Is this version mismatch intended? If not I can add another commit to this PR to fix it.