### PR TITLE
Add Travis CI badge to Cargo.toml, fixes #76

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,8 @@ description = """
 A macro to generate structures which behave like bitflags.
 """
 
+[badges]
+travis-ci = { repository = "rust-lang-nursery/bitflags" }
+
 [features]
 unstable_testing = []


### PR DESCRIPTION
From the [Cargo docs](http://doc.crates.io/manifest.html#package-metadata) it looks like the `travis-ci` badge only supports a `repository` and `branch` attribute. As far as I see Travis CI is the only service in use for this repository and the default  branch is `master`, so this should be fine.