### PR TITLE
Fix the implementation of Formatting traits when other formatting traits were present in scope.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,22 +393,22 @@ macro_rules! __impl_bitflags {
         }
         impl $crate::_core::fmt::Binary for $BitFlags {
             fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                self.bits.fmt(f)
+                $crate::_core::fmt::Binary::fmt(&self.bits, f)
             }
         }
         impl $crate::_core::fmt::Octal for $BitFlags {
             fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                self.bits.fmt(f)
+                $crate::_core::fmt::Octal::fmt(&self.bits, f)
             }
         }
         impl $crate::_core::fmt::LowerHex for $BitFlags {
             fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                self.bits.fmt(f)
+                $crate::_core::fmt::LowerHex::fmt(&self.bits, f)
             }
         }
         impl $crate::_core::fmt::UpperHex for $BitFlags {
             fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                self.bits.fmt(f)
+                $crate::_core::fmt::UpperHex::fmt(&self.bits, f)
             }
         }
 

--- a/tests/conflicting_trait_impls.rs
+++ b/tests/conflicting_trait_impls.rs
@@ -1,0 +1,20 @@
+#![allow(dead_code)]
+#![no_std]
+
+#[macro_use]
+extern crate bitflags;
+
+#[allow(unused_imports)]
+use core::fmt::Display;
+
+bitflags! {
+    /// baz
+    struct Flags: u32 {
+        const A       = 0b00000001;
+    }
+}
+
+#[test]
+fn main() {
+
+}


### PR DESCRIPTION
The formatting impls did not explicitly specify which trait was being invoked, which lead to conflicting implementation errors if any other formatting trait was present in scope before the bitflags! invocation (even just a `use std::fmt::Display` beforehand was enough to cause compilation failures.