### PR TITLE
Document and test the minimum supported Rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ os:
   - osx
 language: rust
 rust:
+  # This version is tested to avoid unintentional bumping of the minimum supported Rust version
+  - 1.20.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ and this to your crate root:
 #[macro_use]
 extern crate bitflags;
 ```
+
+## Rust Version Support
+
+The minimum supported* Rust version is 1.20 due to use of associated constants.
+
+_* As of the current master branch (unreleased)_


### PR DESCRIPTION
Closes #54.

This will cause tests to be run twice on 1.20 (once for the explicit version and once for the latest stable) until 1.21 is released. Testing looks like it takes under a minute for stable on Travis, though, so that shouldn't be too big of a deal.

I didn't know how soon a 1.0 release was planned and therefore left a small footnote in the readme stating that the 1.20 requirement only applies to the unreleased master branch.