### PR TITLE
Avoid re-exporting libcore, remove the need to link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ and this to your crate root:
 
 ```rust
 #[macro_use]
+#[no_link]
 extern crate bitflags;
 ```
 

--- a/compiletest/tests/compile-fail/private_flags.rs
+++ b/compiletest/tests/compile-fail/private_flags.rs
@@ -1,4 +1,5 @@
 #[macro_use]
+#[no_link]
 extern crate bitflags;
 
 mod example {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,9 @@
 //!
 //! ```
 //! #[macro_use]
+//! #[no_link]
 //! extern crate bitflags;
+//! extern crate core;
 //!
 //! bitflags! {
 //!     struct Flags: u32 {
@@ -50,7 +52,9 @@
 //!
 //! ```
 //! #[macro_use]
+//! #[no_link]
 //! extern crate bitflags;
+//! extern crate core;
 //!
 //! use std::fmt;
 //!
@@ -92,7 +96,9 @@
 //!
 //! ```ignore
 //! #[macro_use]
+//! #[no_link]
 //! extern crate bitflags;
+//! extern crate core;
 //!
 //! mod example {
 //!     bitflags! {
@@ -172,7 +178,9 @@
 //!
 //! ```
 //! #[macro_use]
+//! #[no_link]
 //! extern crate bitflags;
+//! extern crate core;
 //!
 //! bitflags! {
 //!     // Results in default value with bits: 0
@@ -194,7 +202,9 @@
 //!
 //! ```
 //! #[macro_use]
+//! #[no_link]
 //! extern crate bitflags;
+//! extern crate core;
 //!
 //! bitflags! {
 //!     struct Flags: u32 {
@@ -225,11 +235,6 @@
 #[macro_use]
 extern crate std;
 
-// Re-export libcore using an alias so that the macros can work without
-// requiring `extern crate core` downstream.
-#[doc(hidden)]
-pub extern crate core as _core;
-
 /// The macro used to generate the flag structure.
 ///
 /// See the [crate level docs](../bitflags/index.html) for complete documentation.
@@ -238,7 +243,9 @@ pub extern crate core as _core;
 ///
 /// ```
 /// #[macro_use]
+/// #[no_link]
 /// extern crate bitflags;
+/// extern crate core;
 ///
 /// bitflags! {
 ///     struct Flags: u32 {
@@ -266,7 +273,9 @@ pub extern crate core as _core;
 ///
 /// ```
 /// #[macro_use]
+/// #[no_link]
 /// extern crate bitflags;
+/// extern crate core;
 ///
 /// use std::fmt;
 ///
@@ -362,8 +371,8 @@ macro_rules! __impl_bitflags {
             )+
         }
     ) => {
-        impl $crate::_core::fmt::Debug for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
+        impl ::core::fmt::Debug for $BitFlags {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 // This convoluted approach is to handle #[cfg]-based flag
                 // omission correctly. For example it needs to support:
                 //
@@ -409,24 +418,24 @@ macro_rules! __impl_bitflags {
                 Ok(())
             }
         }
-        impl $crate::_core::fmt::Binary for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::Binary::fmt(&self.bits, f)
+        impl ::core::fmt::Binary for $BitFlags {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::Binary::fmt(&self.bits, f)
             }
         }
-        impl $crate::_core::fmt::Octal for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::Octal::fmt(&self.bits, f)
+        impl ::core::fmt::Octal for $BitFlags {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::Octal::fmt(&self.bits, f)
             }
         }
-        impl $crate::_core::fmt::LowerHex for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::LowerHex::fmt(&self.bits, f)
+        impl ::core::fmt::LowerHex for $BitFlags {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::LowerHex::fmt(&self.bits, f)
             }
         }
-        impl $crate::_core::fmt::UpperHex for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::UpperHex::fmt(&self.bits, f)
+        impl ::core::fmt::UpperHex for $BitFlags {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::UpperHex::fmt(&self.bits, f)
             }
         }
 
@@ -474,11 +483,11 @@ macro_rules! __impl_bitflags {
             /// Convert from underlying bit representation, unless that
             /// representation contains bits that do not correspond to a flag.
             #[inline]
-            pub fn from_bits(bits: $T) -> $crate::_core::option::Option<$BitFlags> {
+            pub fn from_bits(bits: $T) -> ::core::option::Option<$BitFlags> {
                 if (bits & !$BitFlags::all().bits()) == 0 {
-                    $crate::_core::option::Option::Some($BitFlags { bits: bits })
+                    ::core::option::Option::Some($BitFlags { bits: bits })
                 } else {
-                    $crate::_core::option::Option::None
+                    ::core::option::Option::None
                 }
             }
 
@@ -542,7 +551,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitOr for $BitFlags {
+        impl ::core::ops::BitOr for $BitFlags {
             type Output = $BitFlags;
 
             /// Returns the union of the two sets of flags.
@@ -552,7 +561,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitOrAssign for $BitFlags {
+        impl ::core::ops::BitOrAssign for $BitFlags {
 
             /// Adds the set of flags.
             #[inline]
@@ -561,7 +570,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitXor for $BitFlags {
+        impl ::core::ops::BitXor for $BitFlags {
             type Output = $BitFlags;
 
             /// Returns the left flags, but with all the right flags toggled.
@@ -571,7 +580,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitXorAssign for $BitFlags {
+        impl ::core::ops::BitXorAssign for $BitFlags {
 
             /// Toggles the set of flags.
             #[inline]
@@ -580,7 +589,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitAnd for $BitFlags {
+        impl ::core::ops::BitAnd for $BitFlags {
             type Output = $BitFlags;
 
             /// Returns the intersection between the two sets of flags.
@@ -590,7 +599,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitAndAssign for $BitFlags {
+        impl ::core::ops::BitAndAssign for $BitFlags {
 
             /// Disables all flags disabled in the set.
             #[inline]
@@ -599,7 +608,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::Sub for $BitFlags {
+        impl ::core::ops::Sub for $BitFlags {
             type Output = $BitFlags;
 
             /// Returns the set difference of the two sets of flags.
@@ -609,7 +618,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::SubAssign for $BitFlags {
+        impl ::core::ops::SubAssign for $BitFlags {
 
             /// Disables all flags enabled in the set.
             #[inline]
@@ -618,7 +627,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::Not for $BitFlags {
+        impl ::core::ops::Not for $BitFlags {
             type Output = $BitFlags;
 
             /// Returns the complement of this set of flags.
@@ -628,16 +637,16 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::iter::Extend<$BitFlags> for $BitFlags {
-            fn extend<T: $crate::_core::iter::IntoIterator<Item=$BitFlags>>(&mut self, iterator: T) {
+        impl ::core::iter::Extend<$BitFlags> for $BitFlags {
+            fn extend<T: ::core::iter::IntoIterator<Item=$BitFlags>>(&mut self, iterator: T) {
                 for item in iterator {
                     self.insert(item)
                 }
             }
         }
 
-        impl $crate::_core::iter::FromIterator<$BitFlags> for $BitFlags {
-            fn from_iter<T: $crate::_core::iter::IntoIterator<Item=$BitFlags>>(iterator: T) -> $BitFlags {
+        impl ::core::iter::FromIterator<$BitFlags> for $BitFlags {
+            fn from_iter<T: ::core::iter::IntoIterator<Item=$BitFlags>>(iterator: T) -> $BitFlags {
                 let mut result = Self::empty();
                 result.extend(iterator);
                 result

--- a/tests/conflicting_trait_impls.rs
+++ b/tests/conflicting_trait_impls.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 #[macro_use]
+#[no_link]
 extern crate bitflags;
 
 #[allow(unused_imports)]

--- a/tests/external.rs
+++ b/tests/external.rs
@@ -1,5 +1,7 @@
 #[macro_use]
+#[no_link]
 extern crate bitflags;
+extern crate core;
 
 bitflags! {
     /// baz

--- a/tests/external_no_std.rs
+++ b/tests/external_no_std.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 #[macro_use]
+#[no_link]
 extern crate bitflags;
 
 bitflags! {

--- a/tests/i128_bitflags.rs
+++ b/tests/i128_bitflags.rs
@@ -3,7 +3,9 @@
 #![feature(i128_type)]
 
 #[macro_use]
+#[no_link]
 extern crate bitflags;
+extern crate core;
 
 bitflags! {
     /// baz


### PR DESCRIPTION
r? @alexcrichton this should fix the issue described in https://github.com/rust-lang/rust/pull/44441#issuecomment-328236190.

Note that there is slight merge skew between this and #117; `#[no_link]` should be added to the test being added there, in whichever PR gets merged last.