### PR TITLE
Add `serde` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,8 @@ example_generated = []
 [dev-dependencies]
 # Trick Cargo into testing this crate when we run `cargo test --all`.
 bitflags-compiletest = { path = "compiletest" }
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
 
 [workspace]

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,35 @@
+#[macro_use]
+extern crate bitflags;
+
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+extern crate serde_json;
+
+bitflags! {
+    #[derive(Serialize, Deserialize)]
+    struct Flags: u32 {
+        const A = 1;
+        const B = 2;
+        const C = 4;
+        const D = 8;
+    }
+}
+
+#[test]
+fn serialize() {
+    let flags = Flags::A | Flags::B;
+
+    let serialized = serde_json::to_string(&flags).unwrap();
+
+    assert_eq!(serialized, r#"{"bits":3}"#);
+}
+
+#[test]
+fn deserialize() {
+    let deserialized: Flags = serde_json::from_str(r#"{"bits":12}"#).unwrap();
+
+    let expected = Flags::C | Flags::D;
+
+    assert_eq!(deserialized.bits, expected.bits);
+}


### PR DESCRIPTION
This fixes #108, although there wasn't much to fix. `serde` just works out of the box with `bitflags`.

This pull request simply adds some tests to ensure support for `serde` will work in the future, and also acts as an example.