### PR TITLE
Clean up excessive indentation

### DIFF
--- a/src/example_generated.rs
+++ b/src/example_generated.rs
@@ -6,11 +6,9 @@ bitflags! {
     /// Note that this struct is just for documentation purposes only, it must not be used outside
     /// this crate.
     pub struct Flags: u32 {
-        const FLAG_A       = 0b00000001;
-        const FLAG_B       = 0b00000010;
-        const FLAG_C       = 0b00000100;
-        const FLAG_ABC     = Self::FLAG_A.bits
-                           | Self::FLAG_B.bits
-                           | Self::FLAG_C.bits;
+        const FLAG_A = 0b00000001;
+        const FLAG_B = 0b00000010;
+        const FLAG_C = 0b00000100;
+        const FLAG_ABC = Self::FLAG_A.bits | Self::FLAG_B.bits | Self::FLAG_C.bits;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,12 +23,10 @@
 //!
 //! bitflags! {
 //!     struct Flags: u32 {
-//!         const A       = 0b00000001;
-//!         const B       = 0b00000010;
-//!         const C       = 0b00000100;
-//!         const ABC     = Self::A.bits
-//!                       | Self::B.bits
-//!                       | Self::C.bits;
+//!         const A = 0b00000001;
+//!         const B = 0b00000010;
+//!         const C = 0b00000100;
+//!         const ABC = Self::A.bits | Self::B.bits | Self::C.bits;
 //!     }
 //! }
 //!
@@ -56,8 +54,8 @@
 //!
 //! bitflags! {
 //!     struct Flags: u32 {
-//!         const A   = 0b00000001;
-//!         const B   = 0b00000010;
+//!         const A = 0b00000001;
+//!         const B = 0b00000010;
 //!     }
 //! }
 //!
@@ -97,13 +95,13 @@
 //! mod example {
 //!     bitflags! {
 //!         pub struct Flags1: u32 {
-//!             const A   = 0b00000001;
+//!             const A = 0b00000001;
 //!         }
 //!     }
 //!     bitflags! {
 //! #       pub
 //!         struct Flags2: u32 {
-//!             const B   = 0b00000010;
+//!             const B = 0b00000010;
 //!         }
 //!     }
 //! }
@@ -179,9 +177,9 @@
 //!     // Results in default value with bits: 0
 //!     #[derive(Default)]
 //!     struct Flags: u32 {
-//!         const A       = 0b00000001;
-//!         const B       = 0b00000010;
-//!         const C       = 0b00000100;
+//!         const A = 0b00000001;
+//!         const B = 0b00000010;
+//!         const C = 0b00000100;
 //!     }
 //! }
 //!
@@ -199,9 +197,9 @@
 //!
 //! bitflags! {
 //!     struct Flags: u32 {
-//!         const A       = 0b00000001;
-//!         const B       = 0b00000010;
-//!         const C       = 0b00000100;
+//!         const A = 0b00000001;
+//!         const B = 0b00000010;
+//!         const C = 0b00000100;
 //!     }
 //! }
 //!
@@ -243,12 +241,10 @@ pub extern crate core as _core;
 ///
 /// bitflags! {
 ///     struct Flags: u32 {
-///         const A       = 0b00000001;
-///         const B       = 0b00000010;
-///         const C       = 0b00000100;
-///         const ABC     = Self::A.bits
-///                       | Self::B.bits
-///                       | Self::C.bits;
+///         const A = 0b00000001;
+///         const B = 0b00000010;
+///         const C = 0b00000100;
+///         const ABC = Self::A.bits | Self::B.bits | Self::C.bits;
 ///     }
 /// }
 ///
@@ -273,8 +269,8 @@ pub extern crate core as _core;
 ///
 /// bitflags! {
 ///     struct Flags: u32 {
-///         const A   = 0b00000001;
-///         const B   = 0b00000010;
+///         const A = 0b00000001;
+///         const B = 0b00000010;
 ///     }
 /// }
 ///
@@ -714,16 +710,14 @@ mod tests {
         #[doc = "> "]
         #[doc = "> - Richard Feynman"]
         struct Flags: u32 {
-            const A       = 0b00000001;
+            const A = 0b00000001;
             #[doc = "<pcwalton> macros are way better at generating code than trans is"]
-            const B       = 0b00000010;
-            const C       = 0b00000100;
+            const B = 0b00000010;
+            const C = 0b00000100;
             #[doc = "* cmr bed"]
             #[doc = "* strcat table"]
             #[doc = "<strcat> wait what?"]
-            const ABC     = Self::A.bits
-                          | Self::B.bits
-                          | Self::C.bits;
+            const ABC = Self::A.bits | Self::B.bits | Self::C.bits;
         }
     }
 
@@ -1048,11 +1042,11 @@ mod tests {
         bitflags! {
             /// baz
             struct Flags: foo::Bar {
-                const A       = 0b00000001;
+                const A = 0b00000001;
                 #[cfg(foo)]
-                const B       = 0b00000010;
+                const B = 0b00000010;
                 #[cfg(foo)]
-                const C       = 0b00000010;
+                const C = 0b00000010;
             }
         }
     }

--- a/test_suite/tests/compile-fail/private_flags.rs
+++ b/test_suite/tests/compile-fail/private_flags.rs
@@ -4,12 +4,12 @@ extern crate bitflags;
 mod example {
     bitflags! {
         pub struct Flags1: u32 {
-            const FLAG_A   = 0b00000001;
+            const FLAG_A = 0b00000001;
         }
     }
     bitflags! {
         struct Flags2: u32 {
-            const FLAG_B   = 0b00000010;
+            const FLAG_B = 0b00000010;
         }
     }
 }

--- a/test_suite/tests/conflicting_trait_impls.rs
+++ b/test_suite/tests/conflicting_trait_impls.rs
@@ -9,7 +9,7 @@ use core::fmt::Display;
 bitflags! {
     /// baz
     struct Flags: u32 {
-        const A       = 0b00000001;
+        const A = 0b00000001;
     }
 }
 

--- a/test_suite/tests/external.rs
+++ b/test_suite/tests/external.rs
@@ -4,12 +4,12 @@ extern crate bitflags;
 bitflags! {
     /// baz
     struct Flags: u32 {
-        const A       = 0b00000001;
+        const A = 0b00000001;
         #[doc = "bar"]
-        const B       = 0b00000010;
-        const C       = 0b00000100;
+        const B = 0b00000010;
+        const C = 0b00000100;
         #[doc = "foo"]
-        const ABC     = Flags::A.bits | Flags::B.bits | Flags::C.bits;
+        const ABC = Flags::A.bits | Flags::B.bits | Flags::C.bits;
     }
 }
 

--- a/test_suite/tests/external_no_std.rs
+++ b/test_suite/tests/external_no_std.rs
@@ -6,12 +6,12 @@ extern crate bitflags;
 bitflags! {
     /// baz
     struct Flags: u32 {
-        const A       = 0b00000001;
+        const A = 0b00000001;
         #[doc = "bar"]
-        const B       = 0b00000010;
-        const C       = 0b00000100;
+        const B = 0b00000010;
+        const C = 0b00000100;
         #[doc = "foo"]
-        const ABC     = Flags::A.bits | Flags::B.bits | Flags::C.bits;
+        const ABC = Flags::A.bits | Flags::B.bits | Flags::C.bits;
     }
 }
 

--- a/test_suite/tests/i128_bitflags.rs
+++ b/test_suite/tests/i128_bitflags.rs
@@ -8,10 +8,10 @@ extern crate bitflags;
 bitflags! {
     /// baz
     struct Flags128: u128 {
-        const A       = 0x0000_0000_0000_0000_0000_0000_0000_0001;
-        const B       = 0x0000_0000_0000_1000_0000_0000_0000_0000;
-        const C       = 0x8000_0000_0000_0000_0000_0000_0000_0000;
-        const ABC     = Self::A.bits | Self::B.bits | Self::C.bits;
+        const A = 0x0000_0000_0000_0000_0000_0000_0000_0001;
+        const B = 0x0000_0000_0000_1000_0000_0000_0000_0000;
+        const C = 0x8000_0000_0000_0000_0000_0000_0000_0000;
+        const ABC = Self::A.bits | Self::B.bits | Self::C.bits;
     }
 }
 


### PR DESCRIPTION
I don't like this deliberately aligned, excessively indented style. It seems to have fallen out of favor with rustfmt as well -- see their decision about [alignment of where-clauses](https://github.com/rust-lang-nursery/fmt-rfcs/issues/38).