### PR TITLE
[WIP] Support building without core

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ macro_rules! __bitflags {
         }
 
         __impl_bitflags! {
-            $BitFlags: $T {
+            $BitFlags: $T: $crate::_core {
                 $(
                     $(#[$inner $($args)*])*
                     $Flag = $value;
@@ -375,15 +375,15 @@ macro_rules! __bitflags {
 #[doc(hidden)]
 macro_rules! __impl_bitflags {
     (
-        $BitFlags:ident: $T:ty {
+        $BitFlags:ident: $T:ty: $Core:path {
             $(
                 $(#[$attr:ident $($args:tt)*])*
                 $Flag:ident = $value:expr;
             )+
         }
     ) => {
-        impl $crate::_core::fmt::Debug for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
+        impl $Core::fmt::Debug for $BitFlags {
+            fn fmt(&self, f: &mut $Core::fmt::Formatter) -> $Core::fmt::Result {
                 // This convoluted approach is to handle #[cfg]-based flag
                 // omission correctly. For example it needs to support:
                 //
@@ -429,24 +429,24 @@ macro_rules! __impl_bitflags {
                 Ok(())
             }
         }
-        impl $crate::_core::fmt::Binary for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::Binary::fmt(&self.bits, f)
+        impl $Core::fmt::Binary for $BitFlags {
+            fn fmt(&self, f: &mut $Core::fmt::Formatter) -> $Core::fmt::Result {
+                $Core::fmt::Binary::fmt(&self.bits, f)
             }
         }
-        impl $crate::_core::fmt::Octal for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::Octal::fmt(&self.bits, f)
+        impl $Core::fmt::Octal for $BitFlags {
+            fn fmt(&self, f: &mut $Core::fmt::Formatter) -> $Core::fmt::Result {
+                $Core::fmt::Octal::fmt(&self.bits, f)
             }
         }
-        impl $crate::_core::fmt::LowerHex for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::LowerHex::fmt(&self.bits, f)
+        impl $Core::fmt::LowerHex for $BitFlags {
+            fn fmt(&self, f: &mut $Core::fmt::Formatter) -> $Core::fmt::Result {
+                $Core::fmt::LowerHex::fmt(&self.bits, f)
             }
         }
-        impl $crate::_core::fmt::UpperHex for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::UpperHex::fmt(&self.bits, f)
+        impl $Core::fmt::UpperHex for $BitFlags {
+            fn fmt(&self, f: &mut $Core::fmt::Formatter) -> $Core::fmt::Result {
+                $Core::fmt::UpperHex::fmt(&self.bits, f)
             }
         }
 
@@ -494,11 +494,11 @@ macro_rules! __impl_bitflags {
             /// Convert from underlying bit representation, unless that
             /// representation contains bits that do not correspond to a flag.
             #[inline]
-            pub fn from_bits(bits: $T) -> $crate::_core::option::Option<$BitFlags> {
+            pub fn from_bits(bits: $T) -> $Core::option::Option<$BitFlags> {
                 if (bits & !$BitFlags::all().bits()) == 0 {
-                    $crate::_core::option::Option::Some($BitFlags { bits: bits })
+                    $Core::option::Option::Some($BitFlags { bits: bits })
                 } else {
-                    $crate::_core::option::Option::None
+                    $Core::option::Option::None
                 }
             }
 
@@ -562,7 +562,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitOr for $BitFlags {
+        impl $Core::ops::BitOr for $BitFlags {
             type Output = $BitFlags;
 
             /// Returns the union of the two sets of flags.
@@ -572,7 +572,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitOrAssign for $BitFlags {
+        impl $Core::ops::BitOrAssign for $BitFlags {
 
             /// Adds the set of flags.
             #[inline]
@@ -581,7 +581,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitXor for $BitFlags {
+        impl $Core::ops::BitXor for $BitFlags {
             type Output = $BitFlags;
 
             /// Returns the left flags, but with all the right flags toggled.
@@ -591,7 +591,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitXorAssign for $BitFlags {
+        impl $Core::ops::BitXorAssign for $BitFlags {
 
             /// Toggles the set of flags.
             #[inline]
@@ -600,7 +600,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitAnd for $BitFlags {
+        impl $Core::ops::BitAnd for $BitFlags {
             type Output = $BitFlags;
 
             /// Returns the intersection between the two sets of flags.
@@ -610,7 +610,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::BitAndAssign for $BitFlags {
+        impl $Core::ops::BitAndAssign for $BitFlags {
 
             /// Disables all flags disabled in the set.
             #[inline]
@@ -619,7 +619,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::Sub for $BitFlags {
+        impl $Core::ops::Sub for $BitFlags {
             type Output = $BitFlags;
 
             /// Returns the set difference of the two sets of flags.
@@ -629,7 +629,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::SubAssign for $BitFlags {
+        impl $Core::ops::SubAssign for $BitFlags {
 
             /// Disables all flags enabled in the set.
             #[inline]
@@ -638,7 +638,7 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::ops::Not for $BitFlags {
+        impl $Core::ops::Not for $BitFlags {
             type Output = $BitFlags;
 
             /// Returns the complement of this set of flags.
@@ -648,16 +648,16 @@ macro_rules! __impl_bitflags {
             }
         }
 
-        impl $crate::_core::iter::Extend<$BitFlags> for $BitFlags {
-            fn extend<T: $crate::_core::iter::IntoIterator<Item=$BitFlags>>(&mut self, iterator: T) {
+        impl $Core::iter::Extend<$BitFlags> for $BitFlags {
+            fn extend<T: $Core::iter::IntoIterator<Item=$BitFlags>>(&mut self, iterator: T) {
                 for item in iterator {
                     self.insert(item)
                 }
             }
         }
 
-        impl $crate::_core::iter::FromIterator<$BitFlags> for $BitFlags {
-            fn from_iter<T: $crate::_core::iter::IntoIterator<Item=$BitFlags>>(iterator: T) -> $BitFlags {
+        impl $Core::iter::FromIterator<$BitFlags> for $BitFlags {
+            fn from_iter<T: $Core::iter::IntoIterator<Item=$BitFlags>>(iterator: T) -> $BitFlags {
                 let mut result = Self::empty();
                 result.extend(iterator);
                 result


### PR DESCRIPTION
@dtolnay this is my initial work toward #130, which currently doesn't compile. I'd appreciate any guidance you have!

```
$ cargo test
   Compiling bitflags v1.0.0 (file:///Users/tamird/src/bitflags)
error: expected one of `!`, `+`, `for`, `where`, or `{`, found `::`
   --> src/lib.rs:385:19
    |
385 |           impl $Core::fmt::Debug for $BitFlags {
    |                     ^^ expected one of `!`, `+`, `for`, `where`, or `{` here
    |
   ::: src/example_generated.rs
    |
4   | / bitflags! {
5   | |     /// This is the same `Flags` struct defined in the [crate level example](../index.html#example).
6   | |     /// Note that this struct is just for documentation purposes only, it must not be used outside
7   | |     /// this crate.
...   |
15  | |     }
16  | | }
    | |_- in this macro invocation

error: Could not compile `bitflags`.
warning: build failed, waiting for other jobs to finish...
error: expected one of `!`, `+`, `for`, `where`, or `{`, found `::`
   --> src/lib.rs:385:19
    |
385 |           impl $Core::fmt::Debug for $BitFlags {
    |                     ^^ expected one of `!`, `+`, `for`, `where`, or `{` here
    |
   ::: src/example_generated.rs
    |
4   | / bitflags! {
5   | |     /// This is the same `Flags` struct defined in the [crate level example](../index.html#example).
6   | |     /// Note that this struct is just for documentation purposes only, it must not be used outside
7   | |     /// this crate.
...   |
15  | |     }
16  | | }
    | |_- in this macro invocation

error: Could not compile `bitflags`.

To learn more, run the command again with --verbose.
```