### PR TITLE
Fix the example `Flags` struct

### DIFF
--- a/src/example_generated.rs
+++ b/src/example_generated.rs
@@ -5,10 +5,10 @@ bitflags! {
     /// This is the same `Flags` struct defined in the [crate level example](../index.html#example).
     /// Note that this struct is just for documentation purposes only, it must not be used outside
     /// this crate.
-    pub struct Flags: u32 {
-        const FLAG_A = 0b00000001;
-        const FLAG_B = 0b00000010;
-        const FLAG_C = 0b00000100;
-        const FLAG_ABC = Self::FLAG_A.bits | Self::FLAG_B.bits | Self::FLAG_C.bits;
+    struct Flags: u32 {
+        const A = 0b00000001;
+        const B = 0b00000010;
+        const C = 0b00000100;
+        const ABC = Self::A.bits | Self::B.bits | Self::C.bits;
     }
 }


### PR DESCRIPTION
So that it actually match the one in the crate level docs.