### PR TITLE
Don't include example off docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,8 @@ A macro to generate structures which behave like bitflags.
 travis-ci = { repository = "rust-lang-nursery/bitflags" }
 
 [features]
-default = ["example_generated"]
+default = []
 example_generated = []
+
+[package.metadata.docs.rs]
+features = [ "example_generated" ]


### PR DESCRIPTION
This uses [docs.rs metadata](https://github.com/onur/docs.rs/pull/73) to specify the inclusion of the example, meaning that it doesn't have to be included by default.

Technically a [breaking-change], though... (though the module is specified as not public API)