### PR TITLE
Add a feature for use with nightly that allows marking BitFlag::empty as a const fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ travis-ci = { repository = "rust-lang-nursery/bitflags" }
 
 [features]
 default = []
+const_empty = []
 example_generated = []
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,8 +508,15 @@ macro_rules! __impl_bitflags {
             )+
 
             /// Returns an empty set of flags.
+            #[cfg(not(feature = "const_empty"))]
             #[inline]
             pub fn empty() -> $BitFlags {
+                $BitFlags { bits: 0 }
+            }
+
+            #[cfg(feature = "const_empty")]
+            #[inline]
+            pub const fn empty() -> $BitFlags {
                 $BitFlags { bits: 0 }
             }
 


### PR DESCRIPTION
Not sure if there's interest in having this, but I'd find it useful since it'd let me set `empty()` as an associated const on a `trait`.